### PR TITLE
Add tests for generate_protocol function

### DIFF
--- a/test_protopy.py
+++ b/test_protopy.py
@@ -1,0 +1,37 @@
+import textwrap
+
+import pytest
+
+import protopy
+
+
+def test_generate_protocol_1() -> None:
+    def func(arg):
+        return arg
+
+    expected = textwrap.dedent("""\
+        class Arg(Protocol):
+            ...
+    """)
+
+    result = protopy.generate_protocol(func, "arg")
+
+    assert result == expected
+
+
+def test_generate_protocol_2() -> None:
+    def func(arg):
+        return arg.foo()
+
+    # NOTE(Will): We might be able to also deduce what the return type
+    # of `foo` is and add it to the protocol. But let's not do that for
+    # now.
+    expected = textwrap.dedent("""\
+        class Arg(Protocol):
+            def foo(self):
+                ...
+    """)
+
+    result = protopy.generate_protocol(func, "arg")
+
+    assert result == expected


### PR DESCRIPTION
This commit adds two tests for the generate_protocol function in the
protopy module. These tests are not exhaustive, but serve as a good
starting point for future tests.